### PR TITLE
fix: userModel PK값 자동 생성으로 변경(email field 추가해서 user 구분)

### DIFF
--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim-buster as builder
+FROM python:3.9-buster as builder
 # python 3.8.10 설치
 
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/webapp/config/settings/base.py
+++ b/webapp/config/settings/base.py
@@ -48,6 +48,7 @@ DEFAULT_APPS = [
 
 USER_APPS = [
     'survey',
+    'user',
 ]
 
 INSTALLED_APPS = DEFAULT_APPS + USER_APPS

--- a/webapp/user/models/user.py
+++ b/webapp/user/models/user.py
@@ -7,11 +7,10 @@ class User(BaseModel):
         verbose_name = 'User'
         verbose_name_plural = 'Users'
     
-    kakao_id = models.CharField(
-        verbose_name="카카오 id",
+    email = models.CharField(
+        verbose_name="카카오 계정 이메일",
         max_length=255,
         null=False,
-        primary_key=True,
     )
 
     profile_image = models.CharField(


### PR DESCRIPTION
## 개요
- 기존 카카오 id(고유의 회원번호)를 PK로 쓰는 것에서 PK 장고 자동 생성으로 변경
- user Model에 이메일 field를 추가 -> 이 field를 이용하여 회원 구분

## 작업사항
- kakao_id field 삭제
- email field 추가

## 변경로직
- 내용을 적어주세요.
