### PR TITLE
feat: participant urls, views 구현 & survey urls 수정

### DIFF
--- a/webapp/cart/serializers/cartSerializers.py
+++ b/webapp/cart/serializers/cartSerializers.py
@@ -6,5 +6,5 @@ from cart.models import Cart
 class CartSerializer(serializers.ModelSerializer):
     class Meta:
         model = Cart
-        fields = ["id", "survey", "template", "quantity"]
+        fields = ["uuid", "survey", "template", "quantity"]
         depth = 1

--- a/webapp/participant/models/participant.py
+++ b/webapp/participant/models/participant.py
@@ -92,4 +92,4 @@ class Participant(models.Model):
     # 설문응답의 정성도의 기준
     @property
     def json_quality_standard(self):
-        return self.json_len_count - self.json_duplication_count
+        return (self.json_duplication_count / self.json_len_count) * 100

--- a/webapp/participant/models/participant.py
+++ b/webapp/participant/models/participant.py
@@ -58,7 +58,7 @@ class Participant(models.Model):
                     total_length += len(value)
         except json.JSONDecodeError:
             # JSON 파싱 에러 처리
-            pass
+            return Response({"error": "설문 응답(JSON)를 파싱할 수 없습니다."})
 
         return total_length
 

--- a/webapp/participant/serializers/__init__.py
+++ b/webapp/participant/serializers/__init__.py
@@ -1,0 +1,1 @@
+from participant.serializers import participantSerializer

--- a/webapp/participant/serializers/participantSerializer.py
+++ b/webapp/participant/serializers/participantSerializer.py
@@ -1,0 +1,19 @@
+from rest_framework import serializers
+
+from participant.models import Participant
+
+
+class ParticipantSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Participant
+        fields = [
+            'user',
+            'survey',
+            'json',
+            'created_at',
+            'update_at',
+        ]
+        read_only_fields = [
+            'created_at',
+            'update_at',
+        ]

--- a/webapp/participant/tests.py
+++ b/webapp/participant/tests.py
@@ -1,3 +1,1 @@
 from django.test import TestCase
-
-# Create your tests here.

--- a/webapp/participant/urls.py
+++ b/webapp/participant/urls.py
@@ -1,0 +1,11 @@
+from django.urls import path
+
+from .views.participantListAPIView import ParticipantListAPIView
+from .views.participantDetailAPIView import ParticipantDetailAPIView
+
+app_name = 'participant'
+
+urlpatterns = [
+    path('', ParticipantListAPIView.as_view()),
+    path('<int:pk>/', ParticipantDetailAPIView.as_view()),
+]

--- a/webapp/participant/views/__init__.py
+++ b/webapp/participant/views/__init__.py
@@ -1,0 +1,2 @@
+from .participantListAPIView import ParticipantListAPIView
+from .participantDetailAPIView import ParticipantDetailAPIView

--- a/webapp/participant/views/participantDetailAPIView.py
+++ b/webapp/participant/views/participantDetailAPIView.py
@@ -1,0 +1,31 @@
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from participant.models import Participant
+from participant.serializers.participantSerializer import ParticipantSerializer
+
+
+class ParticipantDetailAPIView(APIView):
+
+    def get_object(self, pk):
+        try:
+            return Participant.objects.get(id=pk)
+        except Participant.DoesNotExist:
+            return Response({"error": "설문이 존재하지 않기 때문에 설문 응답자를 가져올 수 없습니다."})
+
+    def get(self, request, survey_id, pk):
+        participant = self.get_object(pk)
+        serializer = ParticipantSerializer(participant)
+        return Response(serializer.data)
+
+    def put(self, request, survey_id, pk):
+        participant = self.get_object(pk)
+
+        if not participant.survey.is_ongoing:
+            return Response({"error": "설문이 종료되었기 때문에 설문 응답을 수정할 수 없습니다."})
+
+        serializer = ParticipantSerializer(participant, data=request.data)
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data)
+        return Response(serializer.errors, status=400)

--- a/webapp/participant/views/participantListAPIView.py
+++ b/webapp/participant/views/participantListAPIView.py
@@ -1,0 +1,13 @@
+from rest_framework.generics import CreateAPIView, ListAPIView
+from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework import filters
+from participant.models.participant import Participant
+from participant.serializers.participantSerializer import ParticipantSerializer
+
+
+class ParticipantListAPIView(CreateAPIView, ListAPIView):
+    queryset = Participant.objects.all()
+    serializer_class = ParticipantSerializer
+    filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
+    ordering = ['id']
+    ordering_fields = ['survey', 'created_at', 'user']

--- a/webapp/participant/views/views.py
+++ b/webapp/participant/views/views.py
@@ -1,3 +1,0 @@
-from django.shortcuts import render
-
-# Create your views here.

--- a/webapp/survey/urls.py
+++ b/webapp/survey/urls.py
@@ -8,4 +8,5 @@ urlpatterns = [
     path('', SurveyAPIView.as_view()),
     path('<int:survey_id>/', SurveyRetrieveUpdateDestoryAPIView.as_view()),
     path('<int:survey_id>/carts/', include('cart.urls')),
+    path('<int:survey_id>/participants/', include('participant.urls')),
 ]

--- a/webapp/template/serializers/templateSerializer.py
+++ b/webapp/template/serializers/templateSerializer.py
@@ -11,4 +11,9 @@ class TemplateSerializer(serializers.ModelSerializer):
             'gift_sent_count', 'bm_sender_name', 'mc_image_url', 'mc_text', 'item_type', 'product_name',
             'brand_name', 'product_image_url', 'product_thumb_image_url', 'brand_image_url', 'product_price'
         ]
+        read_only_fields = [
+            'pk', 'template_name', 'template_trace_id', 'order_template_status', 'budget_type',
+            'gift_sent_count', 'bm_sender_name', 'mc_image_url', 'mc_text', 'item_type', 'product_name',
+            'brand_name', 'product_image_url', 'product_thumb_image_url', 'brand_image_url', 'product_price'
+        ]
         # template_token을 제외한 모든 필드


### PR DESCRIPTION
## 개요
- participant urls 구현 : localhost/surveys/{pk}/participants/{pk}
- participant model 추가 구현 : @property 3개 추가 (json_len_count,  json_duplication_count, json_quality_standard)
- participant views 구현 : 
    - participantListAPIView(get, post)
    - participantDetailAPIView(get, put)
- template serializer 수정 : 필드들을 read_only_fields에 추가

## 작업사항
- 위와 동일

## 변경로직
- 위와 동일
