### PR TITLE
fix: 당첨확률 높은 순과 마감 임박 순에서 진행 중인 설문만 filtering 후 ordering 적용

### DIFF
--- a/webapp/survey/views/surveyAPIView.py
+++ b/webapp/survey/views/surveyAPIView.py
@@ -18,8 +18,13 @@ class WinningPercentageOrderingFilter(filters.OrderingFilter):
 
         if ordering:
             if ordering[0] == 'winningPercentage' or ordering[0] == '-winningPercentage':
+                queryset = queryset.filter(end_at__gte=date.today())
                 is_descending = ordering[0].startswith('-')
                 return sorted(queryset, key=lambda p: p.winningPercentage, reverse=is_descending)
+            if ordering[0] == 'end_at' or ordering[0] == '-end_at':
+                queryset = queryset.filter(end_at__gte=date.today())
+                is_descending = ordering[0].startswith('-')
+                return sorted(queryset, key=lambda p: p.end_at, reverse=is_descending)
             else:
                 return queryset.order_by(*ordering)
 


### PR DESCRIPTION
## 개요
- 당첨확률 높은 순과 마감 임박 순에서 진행 중인 설문만 filtering 후 ordering 적용

## 작업사항
- survey view의 custom ordering filter에서 queryset을 filtering 시켜줌

## 변경로직
- 내용을 적어주세요.
